### PR TITLE
[00003-0] Implementing PCA9685 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,8 @@ SYSTEM_SCRIPT_DIR = $(STM_LIB_DIR)/Project/Peripheral_Examples/FLASH_Program
 # Files
 SOURCES =  src/main.c \
            src/drivers/gpio.c \
-           src/drivers/i2c.c
+           src/drivers/i2c.c \
+           src/drivers/pca9685.c
 SOURCES += $(STM_LIB_DIR)/Libraries/CMSIS/Device/ST/STM32F30x/Source/Templates/TrueSTUDIO/startup_stm32f30x.s \
            $(SYSTEM_SCRIPT_DIR)/system_stm32f30x.c
 SOURCES += stm32f30x_rcc.c \

--- a/src/drivers/i2c.h
+++ b/src/drivers/i2c.h
@@ -6,9 +6,9 @@
 #include "stm32f30x_i2c.h"
 #include "stm32f30x_rcc.h"
 
-void i2c_init();
-void gpio_for_i2c_init();
-void i2c_read(uint8_t device_address, uint8_t device_register, uint8_t *buffer, uint8_t size);
-void i2c_write(uint8_t device_address, uint8_t device_register, uint8_t *buffer, uint8_t size);
+void i2c1_init();
+void gpio_for_i2c1_init();
+void i2c_read(I2C_TypeDef* I2Cx, uint8_t device_address, uint8_t device_register, uint8_t *buffer, uint8_t size);
+void i2c_write(I2C_TypeDef* I2Cx, uint8_t device_address, uint8_t device_register, uint8_t *buffer, uint8_t size);
 
 #endif // LED_HEADLIGHTS_I2C_H

--- a/src/drivers/pca9685.c
+++ b/src/drivers/pca9685.c
@@ -1,0 +1,57 @@
+#include "pca9685.h"
+#include "i2c.h"
+
+void pca9685_init(uint16_t frequency)
+{
+    pca9685_set_pwm_frequency(frequency);
+    pca9685_set_bit(PCA9685_MODE1, PCA9685_MODE1_AI_BIT, 1);
+}
+
+void pca9685_set_pwm(uint8_t channel, uint16_t on_time, uint16_t off_time)
+{
+    uint8_t register_address;
+    uint8_t pwm[4];
+    register_address = PCA9685_LED0_ON_L + (4 * channel);
+
+    pwm[0] = on_time & 0xFF;
+    pwm[1] = on_time >> 8;
+    pwm[2] = off_time & 0xFF;
+    pwm[3] = off_time >> 8;
+
+    i2c_write(PCA9685_I2C, PCA9685_ADDRESS, register_address, pwm, 4);
+}
+
+void pca9685_set_pwm_frequency(uint16_t frequency)
+{
+    uint8_t prescale;
+
+    if (frequency >= 1526) {
+        prescale = 0x03;
+    } else if (frequency <= 24) {
+        prescale = 0xFF;
+    } else {
+        // Prescale changes 3 to 255 for 1526Hz to 24Hz
+        prescale = 25000000 / (4096 * frequency);
+    }
+
+    pca9685_set_bit(PCA9685_MODE1, PCA9685_MODE1_SLEEP_BIT, 1);
+    i2c_write(PCA9685_I2C, PCA9685_ADDRESS, PCA9685_PRE_SCALE, &prescale, 1);
+    pca9685_set_bit(PCA9685_MODE1, PCA9685_MODE1_SLEEP_BIT, 0);
+    pca9685_set_bit(PCA9685_MODE1, PCA9685_MODE1_RESTART_BIT, 1);
+}
+
+void pca9685_set_bit(uint8_t device_register, uint8_t bit, uint8_t value)
+{
+    uint8_t read_value;
+    
+    // Read all 8 bits and set only one bit to 0/1 and write all 8 bits back
+    i2c_read(PCA9685_I2C, PCA9685_ADDRESS, device_register, &read_value, 1);
+
+    if (value == 0) {
+        read_value &= ~(1 << bit);
+    } else {
+        read_value |= (1 << bit);
+    }
+
+    i2c_write(PCA9685_I2C, PCA9685_ADDRESS, device_register, &read_value, 1);
+}

--- a/src/drivers/pca9685.h
+++ b/src/drivers/pca9685.h
@@ -1,0 +1,24 @@
+#ifndef LED_HEADLIGHTS_PCA9685_H
+#define LED_HEADLIGHTS_PCA9685_H
+
+#include "stm32f30x.h"
+#include "stm32f30x_gpio.h"
+#include "stm32f30x_rcc.h"
+
+#define PCA9685_ADDRESS             0x80
+#define PCA9685_MODE1               0x0
+#define PCA9685_PRE_SCALE           0xFE
+#define PCA9685_LED0_ON_L           0x6
+#define PCA9685_MODE1_SLEEP_BIT     0x4
+#define PCA9685_MODE1_AI_BIT        0x5
+#define PCA9685_MODE1_RESTART_BIT   0x7
+#define PCA9685_DEFAULT_FREQUENCY   5000
+
+#define PCA9685_I2C                 I2C1    // Default I2C device for the PCA9685
+
+void pca9685_init(uint16_t frequency);
+void pca9685_set_pwm(uint8_t channel, uint16_t on_time, uint16_t off_time);
+void pca9685_set_pwm_frequency(uint16_t frequency);
+void pca9685_set_bit(uint8_t device_register, uint8_t bit, uint8_t value);
+
+#endif // LED_HEADLIGHTS_PCA9685_H

--- a/src/main.c
+++ b/src/main.c
@@ -1,31 +1,42 @@
 #include "stm32f30x.h"
 #include "drivers/i2c.h"
 #include "drivers/gpio.h"
-
-#define PCA9685_ADDRESS              0x80
-#define PCA9685_MODE1                0x0         // datasheet page no 10/52
-#define PCA9685_PRE_SCALE            0xFE        // datasheet page no 13/52
-#define PCA9685_LED0_ON_L            0x6         // datasheet page no 10/52
-#define PCA9685_MODE1_SLEEP_BIT      4           // datasheet page no 14/52
-#define PCA9685_MODE1_AI_BIT         5           // datasheet page no 14/52
-#define PCA9685_MODE1_RESTART_BIT    7           // datasheet page no 14/52
-
-uint8_t i2c_buffer[256];
+#include "drivers/pca9685.h"
 
 int main(void)
 {
-    i2c_init();
-    gpio_for_i2c_init();
+    i2c1_init();
+
+    gpio_for_i2c1_init();
     gpio_init();
+    
+    pca9685_init(PCA9685_DEFAULT_FREQUENCY);
 
-    while (1) {
-        i2c_read(PCA9685_ADDRESS, PCA9685_MODE1, i2c_buffer, 1);
+    uint16_t counter = 0;
+    uint16_t interanl_counter_max = 4095;
 
-        if (0 != i2c_buffer[0]) {
-            GPIO_SetBits(GPIOE, GPIO_Pin_8);
-        } else if (1 != i2c_buffer[0]) {
-            GPIO_SetBits(GPIOE, GPIO_Pin_11);
+    while (1)  {
+        while (counter < interanl_counter_max)
+        {
+            pca9685_set_pwm(0, 0, counter);
+            pca9685_set_pwm(1, 0, counter);
+            pca9685_set_pwm(2, 0, counter);
+            pca9685_set_pwm(3, 0, counter);
+
+            counter += 1;
         }
+
+        while (counter > 0)
+        {
+            pca9685_set_pwm(0, 0, counter);
+            pca9685_set_pwm(1, 0, counter);
+            pca9685_set_pwm(2, 0, counter);
+            pca9685_set_pwm(3, 0, counter);
+
+            counter -= 1;
+        }
+
+        GPIO_SetBits(GPIOE, GPIO_Pin_8 | GPIO_Pin_11);
     }
 
     return 0;


### PR DESCRIPTION
The I2C driver (i2c.h, i2c.c files) was modified in order to work with diffirent I2C devices. Added new argument I2C_TypeDef* I2Cx.

The PCA9685 (later as PCA) driver is supposed to be used with I2C1 device, which is denoted in PCA9685_I2C variable definition. To init the PCA9685 device a user have to call the pca9685_init function and pass to it required frequency for the PCA. The user can set the PWM power for a separete channel with a pca9685_set_pwm function.