### PR TITLE
HL-2 [FEATURE] Implementing RX CAN device

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@
 *.bin
 *.elf
 *.hex
-build

--- a/build/.gitignore
+++ b/build/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/src/drivers/can.c
+++ b/src/drivers/can.c
@@ -23,6 +23,41 @@ uint8_t can_init()
     return CAN_Init(CAN1, &can);
 }
 
+void can_filter_init()
+{
+    CAN_FilterInitTypeDef filter;
+
+    filter.CAN_FilterNumber = 0;
+    filter.CAN_FilterActivation = ENABLE;
+    filter.CAN_FilterMode = CAN_FilterMode_IdMask;
+    filter.CAN_FilterFIFOAssignment = CAN_FilterFIFO0;
+    filter.CAN_FilterIdHigh = 0;
+    filter.CAN_FilterIdLow = 0;
+    filter.CAN_FilterMaskIdHigh = 0;
+    filter.CAN_FilterMaskIdLow = 0;
+    filter.CAN_FilterScale = CAN_FilterScale_16bit;
+
+    CAN_FilterInit(&filter);
+}
+
+uint8_t can_read(CAN_TypeDef* canx, uint8_t fifo_number, CanRxMsg* msg)
+{
+    if (fifo_number == CAN_FIFO0) {
+        if (CAN_GetFlagStatus(canx, CAN_FLAG_FMP0) != SET) {
+            return 1;
+        }
+    } else {
+        if (CAN_GetFlagStatus(canx, CAN_FLAG_FMP1) != SET) {
+            return 1;
+        }
+    }
+
+    CAN_Receive(canx, fifo_number, msg);
+    CAN_FIFORelease(canx, fifo_number);
+
+    return 0;
+}
+
 uint8_t can_write(CanTxMsg* msg)
 {
     uint8_t mb = 0;

--- a/src/drivers/can.h
+++ b/src/drivers/can.h
@@ -7,6 +7,8 @@
 #include "stm32f30x_can.h"
 
 uint8_t can_init();
+void can_filter_init();
+uint8_t can_read(CAN_TypeDef* canx, uint8_t fifo_number, CanRxMsg* msg);
 uint8_t can_write(CanTxMsg* msg);
 
 #endif // LED_HEADLIGHTS_CAN_H

--- a/src/rx/main.c
+++ b/src/rx/main.c
@@ -2,18 +2,31 @@
 #include "drivers/i2c.h"
 #include "drivers/gpio.h"
 #include "drivers/pca9685.h"
+#include "drivers/can.h"
 
 int main(void)
 {
     gpio_output_mode_init();
     gpio_i2c_mode_init();
     i2c1_init();
+    gpio_can_mode_init();
     pca9685_init(PCA9685_DEFAULT_FREQUENCY);
+    
+    if (can_init() == CAN_InitStatus_Success) {
+        gpio_write_bit(GPIOE, GPIO_Pin_11, Bit_SET);
+    }
+    can_filter_init();
 
     uint16_t counter = 0;
     uint16_t interanl_counter_max = 4095;
 
     while (1)  {
+        CanRxMsg msg;
+
+        if (can_read(CAN1, CAN_FIFO0, &msg) == 0) {
+            gpio_write_bit(GPIOE, GPIO_Pin_8, Bit_SET);    
+        }
+
         while (counter < interanl_counter_max)
         {
             pca9685_set_pwm(0, 0, counter);
@@ -22,6 +35,10 @@ int main(void)
             pca9685_set_pwm(3, 0, counter);
 
             counter += 1;
+        }
+
+        if (msg.Data[2] == 0) {
+            gpio_write_bit(GPIOE, GPIO_Pin_10, Bit_SET);
         }
 
         while (counter > 0)
@@ -34,7 +51,7 @@ int main(void)
             counter -= 1;
         }
 
-        gpio_write_bit(GPIOE, GPIO_Pin_8 | GPIO_Pin_11, Bit_SET);
+        gpio_write_bit(GPIOE, GPIO_Pin_10, Bit_RESET);
     }
 
     return 0;


### PR DESCRIPTION
The can_filter_init method added in order to receive all the message from the CAN Bus, because in our case there is no more additional devices and any potential device should receive ach message from TX node.