### PR TITLE
HL-10 [FEATURE]: Implementing interrupt support for I2C

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,12 +27,12 @@ SOURCES = src/tx/main.c
 else ifeq ($(TARGET_NAME),RX)
 TARGET = $(BUILD_DIR)/rx
 SOURCES = src/rx/main.c \
-          src/drivers/i2c.c \
           src/drivers/pca9685.c 
 endif
 
 SOURCES += src/drivers/gpio.c \
            src/drivers/can.c \
+           src/drivers/i2c.c \
            src/drivers/stm32f30x_it.c
 
 SOURCES += $(STM_LIB_DIR)/Libraries/CMSIS/Device/ST/STM32F30x/Source/Templates/TrueSTUDIO/startup_stm32f30x.s \

--- a/src/drivers/gpio.c
+++ b/src/drivers/gpio.c
@@ -34,26 +34,6 @@ void gpio_input_mode_init()
     GPIO_Init(GPIOD, &gpio);
 }
 
-/**
- * Configure I2C pins 
- */
-void gpio_i2c_mode_init()
-{
-    RCC_AHBPeriphClockCmd(RCC_AHBPeriph_GPIOB, ENABLE);
-
-    GPIO_PinAFConfig(GPIOB, GPIO_PinSource6, GPIO_AF_4);
-    GPIO_PinAFConfig(GPIOB, GPIO_PinSource7, GPIO_AF_4);
-
-    GPIO_InitTypeDef gpio;
-
-    gpio.GPIO_Pin = GPIO_Pin_6 | GPIO_Pin_7;
-    gpio.GPIO_Mode = GPIO_Mode_AF;
-    gpio.GPIO_Speed = GPIO_Speed_50MHz;
-    gpio.GPIO_OType = GPIO_OType_OD;
-    gpio.GPIO_PuPd = GPIO_PuPd_UP;
-    GPIO_Init(GPIOB, &gpio);
-}
-
 BitAction gpio_read_bit(GPIO_TypeDef* gpiox, uint16_t pin)
 {
     if ((gpiox->IDR & pin) != (uint32_t)Bit_RESET) {

--- a/src/drivers/gpio.h
+++ b/src/drivers/gpio.h
@@ -14,7 +14,6 @@ typedef enum {
 
 void gpio_output_mode_init();
 void gpio_input_mode_init();
-void gpio_i2c_mode_init();
 BitAction gpio_read_bit(GPIO_TypeDef* gpiox, uint16_t pin);
 void gpio_write_bit(GPIO_TypeDef* gpiox, uint16_t pin, BitAction value);
 

--- a/src/drivers/i2c.c
+++ b/src/drivers/i2c.c
@@ -1,24 +1,103 @@
 #include "i2c.h"
 
+uint8_t             *i2c_tx_buffer = 0;
+uint8_t             *i2c_rx_buffer = 0;
+volatile uint16_t   i2c_tx_size    = 0;
+volatile uint16_t   i2c_rx_size    = 0;
+volatile uint16_t   i2c_tx_index   = 0;
+volatile uint16_t   i2c_rx_index   = 0;
+volatile i2c_mode_t i2c_mode       = I2C_MODE_IDLE;
+
 void i2c1_init()
 {
-    // Enable RCC clock for I2C1
+    RCC_AHBPeriphClockCmd(RCC_AHBPeriph_GPIOB, ENABLE);     /* Enable GPIOB Clock */
+
+    GPIO_InitTypeDef gpio;
+    GPIO_StructInit(&gpio);     /* Reset gpio */
+
+    gpio.GPIO_Pin   = GPIO_Pin_6 | GPIO_Pin_7;
+    gpio.GPIO_Mode  = GPIO_Mode_AF;
+    gpio.GPIO_OType = GPIO_OType_OD;
+    gpio.GPIO_Speed = GPIO_Speed_50MHz;
+    gpio.GPIO_PuPd  = GPIO_PuPd_NOPULL;
+
+    GPIO_Init(GPIOB, &gpio);
+
+    GPIO_PinAFConfig(GPIOB, GPIO_PinSource6, GPIO_AF_4);    /* I2C1 SCL */
+    GPIO_PinAFConfig(GPIOB, GPIO_PinSource7, GPIO_AF_4);    /* I2C1 SDA */
+
     RCC_APB1PeriphClockCmd(RCC_APB1Periph_I2C1, ENABLE);
 
-    I2C_InitTypeDef I2C_InitStruct;
+    I2C_InitTypeDef i2c;
+    I2C_StructInit(&i2c);   /* Reset i2c */
 
-    I2C_InitStruct.I2C_Timing = 0x20B;
-    I2C_InitStruct.I2C_Mode = I2C_Mode_I2C;
-    I2C_InitStruct.I2C_OwnAddress1 = 0x0;
-    I2C_InitStruct.I2C_Ack = I2C_Ack_Enable;
-    I2C_InitStruct.I2C_AcknowledgedAddress = I2C_AcknowledgedAddress_7bit;
+    i2c.I2C_Timing              = 0x20E;
+    i2c.I2C_Mode                = I2C_Mode_I2C;
+    i2c.I2C_OwnAddress1         = 0x00;
+    i2c.I2C_Ack                 = I2C_Ack_Enable;
+    i2c.I2C_AcknowledgedAddress = I2C_AcknowledgedAddress_7bit;
 
-    I2C_Init(I2C1, &I2C_InitStruct);
-
+    I2C_Init(I2C1, &i2c);
     I2C_Cmd(I2C1, ENABLE);
+
+    I2C_ITConfig(I2C1,
+                 I2C_IT_ERRI | I2C_IT_TCI | I2C_IT_STOPI |
+                 I2C_IT_NACKI | I2C_IT_ADDRI | I2C_IT_RXI | I2C_IT_TXI,
+                 ENABLE);
+
+    NVIC_InitTypeDef nvic;
+
+    nvic.NVIC_IRQChannel                   = I2C1_EV_IRQn;
+    nvic.NVIC_IRQChannelPreemptionPriority = 0;
+    nvic.NVIC_IRQChannelSubPriority        = 0;
+    nvic.NVIC_IRQChannelCmd                = ENABLE;
+    NVIC_Init(&nvic);
+
+    nvic.NVIC_IRQChannel                   = I2C1_ER_IRQn;
+    NVIC_Init(&nvic);
 }
 
-void i2c_read(I2C_TypeDef* i2cx, uint8_t device_address, uint8_t device_register, uint8_t *buffer, uint8_t size)
+void i2c_master_transmit_it(I2C_TypeDef* i2cx, uint8_t slave_addr, uint8_t *b_data, uint16_t size)
+{
+    if (0 == size) {
+        return;
+    }
+
+    i2c_tx_buffer = b_data;
+    i2c_tx_size   = size;
+    i2c_tx_index  = 0;
+    i2c_mode      = I2C_MODE_TX;
+
+    uint16_t address_bits = (uint16_t)(slave_addr << 1);
+
+    I2C_TransferHandling(i2cx,
+                         address_bits,
+                         size,
+                         I2C_AutoEnd_Mode,
+                         I2C_Generate_Start_Write);
+}
+
+void i2c_master_receive_it(I2C_TypeDef* i2cx, uint8_t slave_addr, uint8_t *b_data, uint16_t size)
+{
+    if (0 == size) {
+        return;
+    }
+
+    i2c_rx_buffer = b_data;
+    i2c_rx_size   = size;
+    i2c_rx_index  = 0;
+    i2c_mode      = I2C_MODE_RX;
+
+    uint16_t address_bits = (uint16_t)(slave_addr << 1);
+
+    I2C_TransferHandling(i2cx,
+                         address_bits,
+                         size,
+                         I2C_AutoEnd_Mode,
+                         I2C_Generate_Start_Read);
+}
+
+void i2c_master_receive_polling(I2C_TypeDef* i2cx, uint8_t device_address, uint8_t device_register, uint8_t *buffer, uint8_t size)
 {
     // Check whether the I2C bus is idle
     while (I2C_GetFlagStatus(i2cx, I2C_FLAG_BUSY));
@@ -51,7 +130,7 @@ void i2c_read(I2C_TypeDef* i2cx, uint8_t device_address, uint8_t device_register
     I2C_ClearFlag(i2cx, I2C_ICR_STOPCF);
 }
 
-void i2c_write(I2C_TypeDef* i2cx, uint8_t device_address, uint8_t device_register, uint8_t *buffer, uint8_t size)
+void i2c_master_transmit_polling(I2C_TypeDef* i2cx, uint8_t device_address, uint8_t device_register, uint8_t *buffer, uint8_t size)
 {
     // Check whether the I2C bus is idle
     while (I2C_GetFlagStatus(i2cx, I2C_FLAG_BUSY));

--- a/src/drivers/i2c.h
+++ b/src/drivers/i2c.h
@@ -4,10 +4,27 @@
 #include "stm32f30x.h"
 #include "stm32f30x_gpio.h"
 #include "stm32f30x_i2c.h"
+#include "stm32f30x_misc.h"
 #include "stm32f30x_rcc.h"
 
-void i2c1_init();
-void i2c_read(I2C_TypeDef* i2cx, uint8_t device_address, uint8_t device_register, uint8_t *buffer, uint8_t size);
-void i2c_write(I2C_TypeDef* i2cx, uint8_t device_address, uint8_t device_register, uint8_t *buffer, uint8_t size);
+typedef enum {
+    I2C_MODE_IDLE,
+    I2C_MODE_TX,
+    I2C_MODE_RX
+} i2c_mode_t;
+
+extern uint8_t             *i2c_tx_buffer;
+extern uint8_t             *i2c_rx_buffer;
+extern volatile uint16_t   i2c_tx_size;
+extern volatile uint16_t   i2c_rx_size;
+extern volatile uint16_t   i2c_tx_index;
+extern volatile uint16_t   i2c_rx_index;
+extern volatile i2c_mode_t i2c_mode;
+
+void i2c1_init(void);
+void i2c_master_transmit_it(I2C_TypeDef* i2cx, uint8_t slave_addr, uint8_t *b_data, uint16_t size);
+void i2c_master_receive_it(I2C_TypeDef* i2cx, uint8_t slave_addr, uint8_t *b_data, uint16_t size);
+void i2c_master_receive_polling(I2C_TypeDef* i2cx, uint8_t device_address, uint8_t device_register, uint8_t *buffer, uint8_t size);
+void i2c_master_transmit_polling(I2C_TypeDef* i2cx, uint8_t device_address, uint8_t device_register, uint8_t *buffer, uint8_t size);
 
 #endif // LED_HEADLIGHTS_I2C_H

--- a/src/drivers/pca9685.c
+++ b/src/drivers/pca9685.c
@@ -1,5 +1,4 @@
 #include "pca9685.h"
-#include "i2c.h"
 
 void pca9685_init(uint16_t frequency)
 {
@@ -7,51 +6,123 @@ void pca9685_init(uint16_t frequency)
     pca9685_set_bit(PCA9685_MODE1, PCA9685_MODE1_AI_BIT, 1);
 }
 
-void pca9685_set_pwm(uint8_t channel, uint16_t on_time, uint16_t off_time)
+pca9685_status_t pca9685_set_pwm_frequency(uint16_t frequency)
 {
-    uint8_t register_address;
-    uint8_t pwm[4];
-    register_address = PCA9685_LED0_ON_L + (4 * channel);
-
-    pwm[0] = on_time & 0xFF;
-    pwm[1] = on_time >> 8;
-    pwm[2] = off_time & 0xFF;
-    pwm[3] = off_time >> 8;
-
-    i2c_write(PCA9685_I2C, PCA9685_ADDRESS, register_address, pwm, 4);
-}
-
-void pca9685_set_pwm_frequency(uint16_t frequency)
-{
-    uint8_t prescale;
+    uint8_t prescale = 0x7F;    /* Default fallback */
 
     if (frequency >= 1526) {
-        prescale = 0x03;
+        prescale = 0x03; 
     } else if (frequency <= 24) {
         prescale = 0xFF;
     } else {
-        // Prescale changes 3 to 255 for 1526Hz to 24Hz
-        prescale = 25000000 / (4096 * frequency);
+        /* Prescale changes 3 to 255 for 1526Hz to 24Hz */
+        unsigned long calc = 25000000UL / (4096UL * (unsigned long)frequency);
+        
+        prescale = (uint8_t)calc;
     }
 
-    pca9685_set_bit(PCA9685_MODE1, PCA9685_MODE1_SLEEP_BIT, 1);
-    i2c_write(PCA9685_I2C, PCA9685_ADDRESS, PCA9685_PRE_SCALE, &prescale, 1);
-    pca9685_set_bit(PCA9685_MODE1, PCA9685_MODE1_SLEEP_BIT, 0);
-    pca9685_set_bit(PCA9685_MODE1, PCA9685_MODE1_RESTART_BIT, 1);
+
+    if (PCA9685_STATUS_ERROR == pca9685_set_bit(PCA9685_MODE1, PCA9685_MODE1_SLEEP_BIT, 1)) {
+        return PCA9685_STATUS_ERROR;
+    }
+
+    if (PCA9685_STATUS_ERROR == pca9685_write_reg(PCA9685_PRE_SCALE, &prescale, 1)) {
+        return PCA9685_STATUS_ERROR;
+    }
+
+    if (PCA9685_STATUS_ERROR == pca9685_set_bit(PCA9685_MODE1, PCA9685_MODE1_SLEEP_BIT, 0)) {
+        return PCA9685_STATUS_ERROR;
+    }
+
+
+    if (PCA9685_STATUS_ERROR == pca9685_set_bit(PCA9685_MODE1, PCA9685_MODE1_RESTART_BIT, 1)) {
+        return PCA9685_STATUS_ERROR;
+    }
+
+    return PCA9685_STATUS_OK;
 }
 
-void pca9685_set_bit(uint8_t device_register, uint8_t bit, uint8_t value)
+pca9685_status_t pca9685_set_bit(uint8_t device_register, uint8_t bit, uint8_t value)
 {
-    uint8_t read_value;
-    
-    // Read all 8 bits and set only one bit to 0/1 and write all 8 bits back
-    i2c_read(PCA9685_I2C, PCA9685_ADDRESS, device_register, &read_value, 1);
+    uint8_t reg_val;
 
-    if (value == 0) {
-        read_value &= ~(1 << bit);
-    } else {
-        read_value |= (1 << bit);
+    if (PCA9685_STATUS_ERROR == pca9685_read_reg(device_register, &reg_val, 1)) {
+        return PCA9685_STATUS_ERROR;
     }
 
-    i2c_write(PCA9685_I2C, PCA9685_ADDRESS, device_register, &read_value, 1);
+    if (value) {
+        reg_val |= (uint8_t)(1 << bit);
+    } else {
+        reg_val &= (uint8_t)~(1 << bit);
+    }
+
+    return pca9685_write_reg(device_register, &reg_val, 1);
+}
+
+pca9685_status_t pca9685_write_reg(uint8_t reg_addr, uint8_t *b_data, uint16_t size)
+{
+    if ((size + 1) > PCA9685_I2C_BUFFER_SIZE) {
+        return PCA9685_STATUS_ERROR;
+    }
+
+    uint8_t txB[16];
+
+    memset(txB, 0, sizeof(txB));
+    txB[0] = reg_addr;
+    memcpy(&txB[1], b_data, size);
+
+    i2c_master_transmit_it(PCA9685_I2C, PCA9685_ADDR_7BIT, txB, (uint16_t)(size + 1));
+
+    if (PCA9685_STATUS_ERROR == pca9685_i2c_wait_util_idle()) {
+        return PCA9685_STATUS_ERROR;
+    }
+
+    return PCA9685_STATUS_OK;
+}
+
+pca9685_status_t pca9685_read_reg(uint8_t reg_addr, uint8_t *b_data, uint16_t size)
+{
+    if (size == 0) {
+        return PCA9685_STATUS_OK;
+    }
+
+    i2c_master_transmit_it(PCA9685_I2C, PCA9685_ADDR_7BIT, &reg_addr, 1);
+    if (PCA9685_STATUS_ERROR == pca9685_i2c_wait_util_idle()) {
+        return PCA9685_STATUS_ERROR;
+    }
+
+    i2c_master_receive_it(PCA9685_I2C, PCA9685_ADDR_7BIT, b_data, size);
+    if (PCA9685_STATUS_ERROR == pca9685_i2c_wait_util_idle()) {
+        return PCA9685_STATUS_ERROR;
+    }
+    
+    return PCA9685_STATUS_OK;
+}
+
+pca9685_status_t pca9685_i2c_wait_util_idle(void)
+{
+    uint32_t timeout = PCA9685_I2C_TIMEOUT;
+    
+    while ((i2c_mode != I2C_MODE_IDLE) && (--timeout > 0)) {
+        /* Wait for I2C to free its state */
+    }
+
+    if (timeout == 0) {
+        return PCA9685_STATUS_ERROR;
+    }
+
+    return PCA9685_STATUS_OK;
+}
+
+pca9685_status_t pca9685_set_pwm(uint8_t channel, uint16_t on_time, uint16_t off_time)
+{
+    uint8_t reg_addr = (uint8_t)(PCA9685_LED0_ON_L + (4 * channel));
+    uint8_t pwm_data[4];
+
+    pwm_data[0] = (uint8_t)(on_time & 0xFF);
+    pwm_data[1] = (uint8_t)((on_time >> 8) & 0xFF);
+    pwm_data[2] = (uint8_t)(off_time & 0xFF);
+    pwm_data[3] = (uint8_t)((off_time >> 8) & 0xFF);
+
+    return pca9685_write_reg(reg_addr, pwm_data, 4);
 }

--- a/src/drivers/pca9685.h
+++ b/src/drivers/pca9685.h
@@ -1,24 +1,37 @@
 #ifndef LED_HEADLIGHTS_PCA9685_H
 #define LED_HEADLIGHTS_PCA9685_H
 
-#include "stm32f30x.h"
-#include "stm32f30x_gpio.h"
-#include "stm32f30x_rcc.h"
+#include "i2c.h"
+#include <string.h>
 
-#define PCA9685_ADDRESS             0x80
-#define PCA9685_MODE1               0x0
+#define PCA9685_ADDR_7BIT           0x40    /* PCA9685 I2C address */
+#define PCA9685_MODE1               0x00
+#define PCA9685_MODE2               0x01
+#define PCA9685_LED0_ON_L           0x06    /* PWM turn on register */
 #define PCA9685_PRE_SCALE           0xFE
-#define PCA9685_LED0_ON_L           0x6
+#define PCA9685_DEFAULT_FREQUENCY   0x32    /* 50 Hz */
+
+#define PCA9685_MODE1_RESTART_BIT   0x7
 #define PCA9685_MODE1_SLEEP_BIT     0x4
 #define PCA9685_MODE1_AI_BIT        0x5
-#define PCA9685_MODE1_RESTART_BIT   0x7
-#define PCA9685_DEFAULT_FREQUENCY   5000
 
-#define PCA9685_I2C                 I2C1    // Default I2C device for the PCA9685
+#define PCA9685_I2C_TIMEOUT         1000000UL
+
+#define PCA9685_I2C_BUFFER_SIZE     0x10
+
+#define PCA9685_I2C                 I2C1
+
+typedef enum {
+    PCA9685_STATUS_OK,
+    PCA9685_STATUS_ERROR
+} pca9685_status_t;
 
 void pca9685_init(uint16_t frequency);
-void pca9685_set_pwm(uint8_t channel, uint16_t on_time, uint16_t off_time);
-void pca9685_set_pwm_frequency(uint16_t frequency);
-void pca9685_set_bit(uint8_t device_register, uint8_t bit, uint8_t value);
+pca9685_status_t pca9685_set_bit(uint8_t device_register, uint8_t bit, uint8_t value);
+pca9685_status_t pca9685_set_pwm_frequency(uint16_t frequency);
+pca9685_status_t pca9685_set_pwm(uint8_t channel, uint16_t on_time, uint16_t off_time);
+pca9685_status_t pca9685_read_reg(uint8_t reg_addr, uint8_t *b_data, uint16_t size);
+pca9685_status_t pca9685_write_reg(uint8_t reg_addr, uint8_t *b_data, uint16_t size);
+pca9685_status_t pca9685_i2c_wait_util_idle(void);
 
 #endif // LED_HEADLIGHTS_PCA9685_H

--- a/src/drivers/stm32f30x_it.c
+++ b/src/drivers/stm32f30x_it.c
@@ -16,3 +16,63 @@ void CAN1_RX1_IRQHandler()
 
     CAN_ClearITPendingBit(CAN1, CAN_IT_FMP1);
 }
+
+void I2C1_EV_IRQHandler(void)
+{
+    /* Transmit interrupt */
+    if (I2C_GetITStatus(I2C1, I2C_IT_TXIS) == SET) {
+        if (i2c_mode == I2C_MODE_TX && i2c_tx_index < i2c_tx_size) {
+            I2C_SendData(I2C1, i2c_tx_buffer[i2c_tx_index++]);
+        }
+    }
+
+    /* Receive interrupt */
+    if (I2C_GetITStatus(I2C1, I2C_IT_RXNE) == SET) {
+        if (i2c_mode == I2C_MODE_RX && i2c_rx_index < i2c_rx_size) {
+            i2c_rx_buffer[i2c_rx_index++] = I2C_ReceiveData(I2C1);
+        }
+    }
+
+    /* Transmit completed interrupt */
+    if (I2C_GetITStatus(I2C1, I2C_IT_TC) == SET) {
+        I2C_ClearITPendingBit(I2C1, I2C_IT_TC);
+    }
+
+    /* Stop signal interrupt */
+    if (I2C_GetITStatus(I2C1, I2C_IT_STOPF) == SET) {
+        I2C_ClearITPendingBit(I2C1, I2C_IT_STOPF);
+        i2c_mode = I2C_MODE_IDLE;
+    }
+
+    /* Address matched for slave mode */
+    if (I2C_GetITStatus(I2C1, I2C_IT_ADDR) == SET) {
+        I2C_ClearITPendingBit(I2C1, I2C_IT_ADDR);
+    }
+
+    /* Not aknowledged message */
+    if (I2C_GetITStatus(I2C1, I2C_IT_NACKF) == SET) {
+        I2C_ClearITPendingBit(I2C1, I2C_IT_NACKF);
+        i2c_mode = I2C_MODE_IDLE;
+    }
+}
+
+void I2C1_ER_IRQHandler(void)
+{
+    /* Bus error */
+    if (I2C_GetITStatus(I2C1, I2C_IT_BERR) == SET) {
+        I2C_ClearITPendingBit(I2C1, I2C_IT_BERR);
+        i2c_mode = I2C_MODE_IDLE;
+    }
+
+    /* Arbitration lost */
+    if (I2C_GetITStatus(I2C1, I2C_IT_ARLO) == SET) {
+        I2C_ClearITPendingBit(I2C1, I2C_IT_ARLO);
+        i2c_mode = I2C_MODE_IDLE;
+    }
+
+    /* Overrun */
+    if (I2C_GetITStatus(I2C1, I2C_IT_OVR) == SET) {
+        I2C_ClearITPendingBit(I2C1, I2C_IT_OVR);
+        i2c_mode = I2C_MODE_IDLE;
+    }
+}

--- a/src/drivers/stm32f30x_it.h
+++ b/src/drivers/stm32f30x_it.h
@@ -3,9 +3,12 @@
 
 #include "drivers/gpio.h"
 #include "drivers/can.h"
+#include "drivers/i2c.h"
 #include "stm32f30x_can.h"
 
 void USB_HP_CAN1_TX_IRQHandler();
 void CAN1_RX1_IRQHandler();
+void I2C1_EV_IRQHandler(void);
+void I2C1_ER_IRQHandler(void);
 
 #endif // LED_HEADLIGHTS_STM32F30X_IT_H

--- a/src/rx/main.c
+++ b/src/rx/main.c
@@ -10,7 +10,6 @@
 int main(void)
 {
     gpio_output_mode_init();
-    gpio_i2c_mode_init();
     i2c1_init();
     pca9685_init(PCA9685_DEFAULT_FREQUENCY);
     


### PR DESCRIPTION
The `PCA9685_ADDR_7BIT` is used as device address instead of 10BIT version ([documentation](https://wiki.seeedstudio.com/Grove-16-Channel_PWM_Driver-PCA9685/)).

In the function `pca9685_write_reg` the program place the `regAddr` (register address) as the first byte in the transmitted array, so bytes after the very first is the bytes to be written in the register.

